### PR TITLE
ci: align pnpm to v10 so CI respects the v9.0 lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10
           run_install: false
 
       # Get pnpm store directory for caching

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10
 
       - name: Get pnpm store directory
         id: pnpm-cache


### PR DESCRIPTION
## What

Bump `pnpm/action-setup` from v8 → v10 in both `ci.yml` and `deploy.yml`.

## Why

`pnpm-lock.yaml` is `lockfileVersion: 9.0` (pnpm 9/10), but CI pinned pnpm 8. CI logs showed:

```
WARN Ignoring not compatible lockfile ... pnpm-lock.yaml
```

So CI **ignored the committed lockfile and re-resolved from `package.json` every run** — non-reproducible installs (dependency versions could drift between runs) and zero pnpm store cache reuse (downloaded everything each time).

## How / effect

With pnpm 10, CI honors the 9.0 lockfile: frozen, reproducible installs with store caching. This also makes lockfile-based Dependabot PRs meaningful again.

## Test

- Verified locally: `pnpm install --frozen-lockfile` passes against the committed lockfile (pnpm 10.13.1, "Lockfile is up to date").
- CI runs on this PR with the new pnpm version and must stay green before merge.
