### PR TITLE
test: add live-site smoke-test harness

### DIFF
--- a/scripts/validation/smoke-test.mjs
+++ b/scripts/validation/smoke-test.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+/**
+ * Smoke test
+ * ==========
+ *
+ * Fetches a representative set of routes and asserts each responds correctly
+ * (status + a content marker). Used to confirm the rendered site actually works
+ * — a green build does not prove pages render.
+ *
+ * Usage:
+ *   node scripts/validation/smoke-test.mjs [baseUrl]
+ *
+ *   # local, against `pnpm preview`
+ *   node scripts/validation/smoke-test.mjs http://localhost:4321
+ *
+ *   # production
+ *   node scripts/validation/smoke-test.mjs https://nathanlane.info
+ *
+ * Default baseUrl: http://localhost:4321
+ * Exit code: 0 if every check passes, 1 if any fail.
+ */
+
+const baseUrl = (process.argv[2] || "http://localhost:4321").replace(/\/$/, "");
+
+/**
+ * Each check: { path, status?, marker?, contentType? }
+ * - status: expected HTTP status (default 200)
+ * - marker: substring that must appear in the body (HTML/XML)
+ * - contentType: substring that must appear in the content-type header
+ */
+const CHECKS = [
+	{ path: "/", marker: "Nathan Lane" },
+	{ path: "/about/", marker: "Nathan Lane" },
+	{ path: "/research/", marker: "Nathan Lane" },
+	// katex math must render in this paper page
+	{ path: "/research/manufacturing-revolutions/", marker: "katex" },
+	{ path: "/writing/", marker: "Nathan Lane" },
+	{ path: "/writing/a-flight-plan-that-fails-boston-review/", marker: "Nathan Lane" },
+	{ path: "/posts/", marker: "Nathan Lane" },
+	{ path: "/tags/", marker: "Nathan Lane" },
+	{ path: "/rss.xml", marker: "<rss" },
+	{ path: "/research/rss.xml", marker: "<rss" },
+	{ path: "/sitemap-index.xml", marker: "<sitemapindex" },
+	// satori + resvg rendered OG image
+	{ path: "/og-image/deepseek.png", contentType: "image/png" },
+	// unknown route must serve a 404
+	{ path: "/this-route-should-not-exist-xyz", status: 404 },
+];
+
+async function run() {
+	console.log(`Smoke testing ${baseUrl}\n`);
+	const failures = [];
+
+	for (const check of CHECKS) {
+		const expectedStatus = check.status ?? 200;
+		const url = `${baseUrl}${check.path}`;
+		let res;
+		try {
+			res = await fetch(url, { redirect: "manual" });
+		} catch (error) {
+			failures.push(`${check.path} — request failed: ${error.message}`);
+			console.log(`  ✗ ${check.path} — request failed: ${error.message}`);
+			continue;
+		}
+
+		const problems = [];
+		if (res.status !== expectedStatus) {
+			problems.push(`status ${res.status} (expected ${expectedStatus})`);
+		}
+		if (check.contentType) {
+			const ct = res.headers.get("content-type") || "";
+			if (!ct.includes(check.contentType)) {
+				problems.push(`content-type "${ct}" missing "${check.contentType}"`);
+			}
+		}
+		if (check.marker) {
+			const body = await res.text();
+			if (!body.includes(check.marker)) {
+				problems.push(`body missing marker "${check.marker}"`);
+			}
+		}
+
+		if (problems.length > 0) {
+			failures.push(`${check.path} — ${problems.join("; ")}`);
+			console.log(`  ✗ ${check.path} — ${problems.join("; ")}`);
+		} else {
+			console.log(`  ✓ ${check.path}`);
+		}
+	}
+
+	console.log("");
+	if (failures.length > 0) {
+		console.error(`Smoke test FAILED: ${failures.length}/${CHECKS.length} checks failed.`);
+		process.exit(1);
+	}
+	console.log(`Smoke test passed: ${CHECKS.length}/${CHECKS.length} checks OK.`);
+}
+
+run();


### PR DESCRIPTION
## What

Add `scripts/validation/smoke-test.mjs` — a dependency-free (Node built-ins) live-site smoke test.

## Why

The deploy gate runs `pnpm run validate`, which proves the site **builds and type-checks** — but not that pages actually **render**. Dependency upgrades (remark/rehype, katex, shiki, satori/resvg OG images) can build clean yet regress output. This harness closes that gap.

## How

Given a base URL, it GETs a representative route set and asserts status + a content marker:
`/`, `/about/`, `/research/`, `/research/manufacturing-revolutions/` (katex), `/writing/` + a post, `/posts/`, `/tags/`, `/rss.xml`, `/research/rss.xml`, `/sitemap-index.xml`, an `/og-image/*.png`, and a 404. Exits non-zero on any failure.

Reused locally (`pnpm preview` → `node scripts/validation/smoke-test.mjs http://localhost:4321`) and against prod (`… https://nathanlane.info`).

## Test

Passes 13/13 against both the local preview build and `https://nathanlane.info`.
