### PR TITLE
Fix rendered local content links

### DIFF
--- a/src/content/post/lane-docs/comprehensive-site-maintenance.md
+++ b/src/content/post/lane-docs/comprehensive-site-maintenance.md
@@ -131,7 +131,7 @@ showcase:
 
 ## SEO and Structured Data
 
-See the dedicated [SEO & Structured Data Maintenance Guide](./seo-structured-data-maintenance) for:
+See the dedicated [SEO & Structured Data Maintenance Guide](/posts/lane-docs/seo-structured-data-maintenance/) for:
 - Updating structured data schemas
 - Testing SEO implementations
 - Managing meta tags
@@ -282,9 +282,9 @@ pnpm check
 - [TypeScript Documentation](https://www.typescriptlang.org/docs)
 
 ### Project-Specific Guides
-- [Adding Documentation Pages](./adding-documentation-pages)
-- [Understanding the Design System](./design-system)
-- [SEO & Structured Data](./seo-structured-data-maintenance)
+- [Adding Documentation Pages](/posts/lane-docs/adding-docs-guide/)
+- [Understanding the Design System](/posts/lane-docs/design-system/)
+- [SEO & Structured Data](/posts/lane-docs/seo-structured-data-maintenance/)
 
 ### Support Channels
 - GitHub Issues for bug reports

--- a/src/content/post/remark-rehype.md
+++ b/src/content/post/remark-rehype.md
@@ -707,7 +707,7 @@ abide by its terms.
 
 [coc]: https://github.com/remarkjs/.github/blob/main/code-of-conduct.md
 
-[license]: license
+[license]: https://github.com/remarkjs/remark-rehype/blob/main/license
 
 [author]: https://wooorm.com
 

--- a/src/test/repo-guards.spec.ts
+++ b/src/test/repo-guards.spec.ts
@@ -71,4 +71,25 @@ describe("public link hygiene", () => {
 		expect(source).toContain("(https://www.giorcellimichela.com/");
 		expect(source).toContain("](/posts/social-image/)");
 	});
+
+	it("does not contain known rendered links to missing local routes", () => {
+		const checkedFiles = [
+			"src/content/post/lane-docs/comprehensive-site-maintenance.md",
+			"src/content/post/remark-rehype.md",
+		];
+		const source = checkedFiles
+			.map((relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), "utf8"))
+			.join("\n");
+
+		expect(source).not.toContain("](./seo-structured-data-maintenance)");
+		expect(source).not.toContain("](./adding-documentation-pages)");
+		expect(source).not.toContain("](./design-system)");
+		expect(source).not.toContain("[license]: license");
+		expect(source).toContain("](/posts/lane-docs/seo-structured-data-maintenance/)");
+		expect(source).toContain("](/posts/lane-docs/adding-docs-guide/)");
+		expect(source).toContain("](/posts/lane-docs/design-system/)");
+		expect(source).toContain(
+			"[license]: https://github.com/remarkjs/remark-rehype/blob/main/license",
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- convert lane-docs guide references from broken relative links to generated root-relative routes
- point copied remark-rehype license reference at the upstream GitHub license URL
- add regression guards for these rendered-link failures

## Verification
- pnpm validate
- DOM-aware rendered local reference scan: checked 6084 refs outside code/pre blocks with no missing local targets

## Notes
- The naive regex crawl still sees code-block examples such as analytics.js, app.js, and /wiki/Dysnomia_(moon); those are intentionally left untouched because they are example code, not rendered public navigation links.