### PR TITLE
fix: smoke:live should only test the prod origin

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"smoke:local": "node scripts/validation/smoke-test.mjs http://localhost:4321",
 		"smoke:prod": "node scripts/validation/smoke-test.mjs https://nathanlane.info",
 		"smoke:pages": "node scripts/validation/smoke-test.mjs https://nathanlane.github.io",
-		"smoke:live": "pnpm run smoke:prod && pnpm run smoke:pages",
+		"smoke:live": "pnpm run smoke:prod",
 		"test": "vitest --run",
 		"test:ui": "vitest --ui",
 		"pre-push": "pnpm run validate",


### PR DESCRIPTION
nathanlane.github.io is a 301 redirect to nathanlane.info — smoke:pages always fails (the test uses redirect:manual). smoke:live now runs smoke:prod only.