### PR TITLE
ci: add gitleaks secret scanning to pre-commit hook and CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,25 @@
 #!/bin/sh
-# Pre-commit hook: reject staging of local-only agentic files
-#
-# AGENTS.md and CLAUDE.md are generated from docs/assistant-workflow.md
+# Pre-commit hook
+# 1. Scan staged changes for secrets (gitleaks)
+# 2. Reject staging of local-only agentic files
+
+# --- Secret scanning ---
+if command -v gitleaks > /dev/null 2>&1; then
+    gitleaks protect --staged --no-banner
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo "ERROR: gitleaks detected a potential secret in staged changes."
+        echo "Review the output above and remove any credentials before committing."
+        echo "If this is a false positive, add an allow-list entry to .gitleaks.toml"
+        exit 1
+    fi
+else
+    echo "WARNING: gitleaks not installed — secret scan skipped."
+    echo "Install: brew install gitleaks  (CI always scans regardless)"
+fi
+
+# --- Agentic file protection ---
+# AGENTS.md and CLAUDE.md are generated from .private/docs/assistant-workflow.md
 # and are kept local-only (gitignored). .claude/ holds subagents, slash
 # commands, prompts, and settings — also local-only.
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,15 @@ jobs:
       # Checkout code
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history required for gitleaks detect
+
+      # Scan full history for secrets — runs before anything else, no deps needed
+      - name: Scan for secrets (gitleaks)
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+            | tar -xz gitleaks
+          ./gitleaks detect --no-banner --exit-code 1
 
       # Setup Node.js
       - name: Setup Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## What

Add gitleaks secret scanning at two layers: pre-commit (local) and CI (non-bypassable gate).

## Pre-commit hook (`.githooks/pre-commit`)

Adds `gitleaks protect --staged` as the first check before each commit. Scans only staged changes — fast, targeted, runs before anything gets into git history. Soft-fails with a warning if gitleaks is not installed (so commits aren't blocked on machines without it); CI is the hard gate. Agentic file protection check runs after.

Install locally: `brew install gitleaks`

## CI (`.github/workflows/ci.yml`)

Adds a **Scan for secrets** step immediately after `actions/checkout`, before Node/pnpm setup — no dependencies needed. Sets `fetch-depth: 0` so the full history is available. Installs gitleaks v8.30.1 and runs `gitleaks detect` on the entire repo history. Hard-fails the build if any secrets are found. This is the non-bypassable gate regardless of local hook state.

## Why two layers

The pre-commit hook gives fast local feedback. CI is the backstop: it runs on every push/PR regardless of whether the local hook was active, installed, or bypassed with `--no-verify`.

## Verification

`pnpm run validate` green (22 tests, 173 pages). gitleaks ran during the commit of this PR and found no leaks.
