### PR TITLE
fix: correctness and SEO/a11y quick wins from code review

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -117,7 +117,7 @@ const socialImageURL = new URL(
 <meta content={siteConfig.author} name="author" />
 
 {/* Theme Colour */}
-<meta content="" name="theme-color" />
+<meta content="#0d0c0b" name="theme-color" />
 
 {/* Open Graph / Facebook */}
 <meta content={articleDate ? "article" : "website"} property="og:type" />

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -4,7 +4,7 @@ import Badge from "@/components/Badge.astro";
 import Pagination from "@/components/Paginator.astro";
 import PostPreview from "@/components/blog/PostPreview.astro";
 import PostSearch from "@/components/blog/PostSearch.astro";
-import { getAllPosts, getUniqueTags, groupPostsByYear } from "@/data/post";
+import { getAllPosts, getUniqueTagsWithCount, groupPostsByYear } from "@/data/post";
 import PageLayout from "@/layouts/Base.astro";
 import type { Page } from "@/types";
 
@@ -16,7 +16,9 @@ export const getStaticPaths = (async ({ paginate }) => {
 	const MAX_TAGS = 12;
 	const allPosts = await getAllPosts();
 	const allPostsCount = allPosts.length;
-	const uniqueTags = getUniqueTags(allPosts).slice(0, MAX_TAGS);
+	const uniqueTags = getUniqueTagsWithCount(allPosts)
+		.slice(0, MAX_TAGS)
+		.map(([tag]) => tag);
 	return paginate(
 		allPosts.sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime()),
 		{

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -10,7 +10,9 @@ import { renderMarkdown } from "@/utils/markdown";
 const allPosts = await getAllPosts();
 const uniqueTags = getUniqueTags(allPosts);
 
-const recentPosts = allPosts.slice(0, 5);
+const recentPosts = [...allPosts]
+	.sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())
+	.slice(0, 5);
 
 const postsPage = await getEntry("pages", "posts");
 if (!postsPage) {

--- a/src/pages/research/rss.xml.ts
+++ b/src/pages/research/rss.xml.ts
@@ -1,5 +1,6 @@
 import { getCollection } from "astro:content";
 import { siteConfig } from "@/site.config";
+import { escapeXml } from "@/utils/xml";
 import rss from "@astrojs/rss";
 
 export const GET = async () => {
@@ -23,11 +24,11 @@ export const GET = async () => {
 			content: item.body || "",
 			categories: item.data.tags || [],
 			customData: `
-        <guid isPermaLink="true">${siteConfig.canonicalUrl}/research/${item.id}/</guid>
-        <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">${item.data.authors}</dc:creator>
-        <status>${item.data.status}</status>
-        <type>${item.data.type}</type>
-        ${item.data.publication ? `<publication>${item.data.publication}</publication>` : ""}
+        <guid isPermaLink="true">${escapeXml(`${siteConfig.canonicalUrl}/research/${item.id}/`)}</guid>
+        <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">${escapeXml(item.data.authors)}</dc:creator>
+        <status>${escapeXml(item.data.status)}</status>
+        <type>${escapeXml(item.data.type)}</type>
+        ${item.data.publication ? `<publication>${escapeXml(item.data.publication)}</publication>` : ""}
       `,
 		})),
 		customData: `

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -2,6 +2,7 @@ import { getCollection } from "astro:content";
 import { getAllPosts } from "@/data/post";
 import { siteConfig } from "@/site.config";
 import { isPublishedEntry } from "@/utils/content";
+import { escapeXml } from "@/utils/xml";
 import rss from "@astrojs/rss";
 
 export const GET = async () => {
@@ -18,7 +19,7 @@ export const GET = async () => {
 			link: `/posts/${post.id}/`,
 			content: post.body || "",
 			categories: post.data.tags || [],
-			customData: `<guid isPermaLink="true">${siteConfig.canonicalUrl}/posts/${post.id}/</guid>`,
+			customData: `<guid isPermaLink="true">${escapeXml(`${siteConfig.canonicalUrl}/posts/${post.id}/`)}</guid>`,
 		})),
 		...research.map((item) => ({
 			title: item.data.title,
@@ -27,7 +28,7 @@ export const GET = async () => {
 			link: `/research/${item.id}/`,
 			content: item.body || "",
 			categories: item.data.tags || [],
-			customData: `<guid isPermaLink="true">${siteConfig.canonicalUrl}/research/${item.id}/</guid>`,
+			customData: `<guid isPermaLink="true">${escapeXml(`${siteConfig.canonicalUrl}/research/${item.id}/`)}</guid>`,
 		})),
 		...writing.map((item) => ({
 			title: item.data.title,
@@ -36,7 +37,7 @@ export const GET = async () => {
 			link: `/writing/${item.id}/`,
 			content: item.body || "",
 			categories: [], // Writing doesn't have tags
-			customData: `<guid isPermaLink="true">${siteConfig.canonicalUrl}/writing/${item.id}/</guid>`,
+			customData: `<guid isPermaLink="true">${escapeXml(`${siteConfig.canonicalUrl}/writing/${item.id}/`)}</guid>`,
 		})),
 	].sort((a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime());
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -815,7 +815,7 @@
 	/* Keyboard focus - visible and consistent */
 	:focus-visible {
 		outline: 2px solid var(--theme-accent);
-		outline-offset: var(--space-0 0.5); /* 3px = 0.5 grid units */
+		outline-offset: 3px; /* 0.5 grid units */
 	}
 
 	/* Dark mode focus adjustment */

--- a/src/styles/links.css
+++ b/src/styles/links.css
@@ -95,7 +95,7 @@ a:focus {
 
 a:focus-visible {
 	outline: 2px solid var(--theme-accent);
-	outline-offset: var(--space-0 0.5);
+	outline-offset: 3px;
 	border-radius: 2px;
 }
 

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -1,0 +1,9 @@
+/** Escape a string for safe interpolation into raw XML (e.g. RSS `customData`). */
+export function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&apos;");
+}


### PR DESCRIPTION
Five high-confidence fixes surfaced by a multi-agent code review, each reviewed against the source before commit.

## Changes
- **RSS feed escaping (correctness — real breakage).** Freeform strings (author lists like `Acemoglu & Robinson`, publication names) and `guid` URLs were interpolated raw into RSS `customData`, producing malformed XML that fails in strict parsers. Adds `src/utils/xml.ts` `escapeXml()` and applies it to `dc:creator`/`status`/`type`/`publication` and all guids. Library-escaped `title`/`description` fields are left untouched (no double-escaping).
- **"Recent Posts" actually recent.** `posts/index.astro` now sorts by `publishDate` desc before slicing, instead of showing arbitrary build-order posts.
- **"Popular Topics" actually popular.** `posts/[...page].astro` now uses the count-sorted `getUniqueTagsWithCount` instead of first-seen tag order.
- **Real `theme-color`.** Empty `<meta name="theme-color">` → `#0d0c0b` (the dark `--theme-bg`); runtime `ThemeProvider` still overrides per theme.
- **Valid focus ring.** `outline-offset: var(--space-0 0.5)` was invalid CSS (declaration dropped → 0 offset); fixed to `3px` in `global.css` and `links.css`.

## Verification
- `astro check` → 0 errors, 0 warnings
- `vitest` → 22/22 pass
- `astro build` → 173 pages
- `xmllint` → both RSS feeds well-formed (escaping confirmed in output)
- `pnpm smoke:local` → 13/13

Remaining review findings (incl. `--frozen-lockfile` hardening) are tracked separately.