### PR TITLE
ci: enforce frozen lockfile and consolidate dependency overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Install dependencies
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       # Run the authoritative repository validation contract
       - name: Validate repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Validate and build
         # Full contract: lint, format:check, generated-file sync, astro check,

--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,3 @@
-# Force specific versions to fix vulnerabilities
-# This will override sub-dependency versions
-overrides:
-  tar-fs: "^3.0.9"
-  prismjs: "^1.30.0"
-  undici: "^6.21.2"
-  brace-expansion: "^2.0.2"
+# Dependency overrides live in pnpm-workspace.yaml (`overrides:`), the single
+# authoritative source under pnpm 10+. An `overrides:` block here has no effect
+# (.npmrc is INI, not YAML) and was removed to avoid implying otherwise.

--- a/package.json
+++ b/package.json
@@ -92,11 +92,5 @@
 		"typescript": "^5.8.3",
 		"vite": "^6.4.3",
 		"vitest": "^4.1.0"
-	},
-	"overrides": {
-		"tar-fs": "3.1.2",
-		"prismjs": "1.30.0",
-		"undici": "6.26.0",
-		"brace-expansion": "2.0.3"
 	}
 }


### PR DESCRIPTION
Hardens the install step and removes two inert override sources, so the security override pins are actually enforced end-to-end.

## Changes
- **`--frozen-lockfile` in CI + deploy.** `pnpm install` → `pnpm install --frozen-lockfile`. Without it, pnpm silently regenerates the lockfile on drift, defeating the CVE override pins. Now a drifted manifest fails the run loudly.
- **Single authoritative override source.** Removed the inert top-level `overrides` block from `package.json` and the `overrides:` block from `.npmrc` (`.npmrc` is INI, not YAML, so that block was always ignored). `pnpm-workspace.yaml` is authoritative under pnpm 10+ — the lockfile's `overrides:` snapshot matches it exactly.

## Verification
- `pnpm install --frozen-lockfile` → **"Already up to date"**, lockfile untouched (committed lockfile already in sync; no regeneration needed).
- Confirmed resolution-neutral: re-ran frozen install after the removals — still green, `pnpm-lock.yaml` unchanged.
- `pnpm run validate` → 0 errors, 22/22 tests, 173 pages built.

## Notes / out of scope
- Build-script approval config (`allowBuilds:` vs `onlyBuiltDependencies:` in `pnpm-workspace.yaml`) is a pnpm 10/11 behavioral difference — left untouched here, to be handled alongside the GitHub Actions / pnpm action-version bump.