### PR TITLE
feat: SEO and a11y batch from code-review backlog

### DIFF
--- a/.gitsecret
+++ b/.gitsecret
@@ -4,7 +4,7 @@
 # Paths to exclude from secret scanning (uses grep -E regex)
 # These are typically documentation, test files, or directories with false positives
 exclude_paths:
-  - "private_notes/"
+  - "\.private/"
   - "CHANGELOG"
   - "Changelog"
   - "SECURITY"

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
 			nesting: true,
 		}),
 		sitemap({
-			filter: (page) => !page.includes("/admin"),
+			filter: (page) => !page.includes("/admin") && !page.includes("/og-image/"),
 		}),
 		mdx(),
 		robotsTxt({

--- a/scripts/maintenance/install-git-hooks.sh
+++ b/scripts/maintenance/install-git-hooks.sh
@@ -42,7 +42,7 @@ REAL_SECRET_PATTERNS='["'"'"'`].*api[_-]?key["'"'"'`]?\s*[:=]\s*["'"'"'`][A-Za-z
 if [ -f .gitsecret ]; then
     EXCLUDE_PATTERNS=$(grep -A20 "exclude_paths:" .gitsecret | grep "^  - " | sed 's/^  - "\(.*\)"$/\1/' | tr '\n' '|' | sed 's/|$//')
 else
-    EXCLUDE_PATTERNS="CHANGELOG|Changelog|SECURITY|README|CLAUDE\.md|\.test\.|\.spec\.|private_notes/"
+    EXCLUDE_PATTERNS="CHANGELOG|Changelog|SECURITY|README|CLAUDE\.md|\.test\.|\.spec\.|\.private/"
 fi
 
 # Function to check if content is likely documentation

--- a/src/components/StructuredData.astro
+++ b/src/components/StructuredData.astro
@@ -99,12 +99,6 @@ switch (type) {
       "@context": "https://schema.org",
       ...personSchema,
       "description": `${siteConfig.jobTitle} at ${siteConfig.organization}. Empirical economist and data scientist studying how economies change.`,
-      "alumniOf": [
-        {
-          "@type": "CollegeOrUniversity",
-          "name": "Harvard University"
-        }
-      ],
       "knowsAbout": [
         "Economics",
         "Industrial Policy",

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -7,7 +7,11 @@ const elsewhereLlinks = socialLinks
 	.map((social) => ({ title: social.friendlyName, href: social.link }));
 
 // Footer sections configuration - built from siteConfig
-const footerSections = [
+const footerSections: {
+	title: string;
+	links?: { title: string; href: string }[];
+	text?: string;
+}[] = [
 	{
 		title: "Here",
 		links: [
@@ -32,13 +36,7 @@ const footerSections = [
 	},
 	{
 		title: "About this site",
-		links: [
-			{
-				title:
-					"Built by me, Nathan Lane, with care using Astro/Tailwind/GitHub Pages, designed with typography in mind. I use Inter (body/headers) and JetBrains Mono (code) for typography.",
-				href: "#",
-			},
-		],
+		text: "Built by me, Nathan Lane, with care using Astro/Tailwind/GitHub Pages, designed with typography in mind. I use Inter (body/headers) and JetBrains Mono (code) for typography.",
 	},
 ];
 
@@ -53,16 +51,20 @@ const currentYear = new Date().getFullYear();
 			{
 				footerSections.map((section) => (
 					<div class="footer-section">
-						<h3 class="footer-section-title">{section.title}</h3>
-						<ul class="footer-links">
-							{(section.links || []).map((link) => (
-								<li>
-									<a href={link.href} class="link-footer">
-										{link.title}
-									</a>
-								</li>
-							))}
-						</ul>
+						<h2 class="footer-section-title">{section.title}</h2>
+						{section.text ? (
+							<p class="footer-section-text">{section.text}</p>
+						) : (
+							<ul class="footer-links">
+								{(section.links || []).map((link) => (
+									<li>
+										<a href={link.href} class="link-footer">
+											{link.title}
+										</a>
+									</li>
+								))}
+							</ul>
+						)}
 					</div>
 				))
 			}
@@ -106,6 +108,14 @@ const currentYear = new Date().getFullYear();
 		max-width: var(--container-max, 80rem);
 		margin: 0 auto;
 		padding: 0 var(--space-4) var(--space-10); /* 0 24px 60px - 2.5 baselines */
+	}
+
+	/* Informational footer copy (non-link section) */
+	.footer-section-text {
+		max-width: 34ch;
+		line-height: 1.5;
+		opacity: 0.64;
+		color: var(--theme-color-600);
 	}
 
 	/* Improved navigation grid with musical spacing */

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,7 @@
 ---
 import { getEntry, render } from "astro:content";
 import PageHeader from "@/components/PageHeader.astro";
+import StructuredData from "@/components/StructuredData.astro";
 import PageLayout from "@/layouts/Base.astro";
 import { siteConfig, socialLinks } from "@/site.config";
 import { renderMarkdown } from "@/utils/markdown";
@@ -31,6 +32,7 @@ const headerDescriptionHtml = headerDescriptionMarkdown
 ---
 
 <PageLayout meta={{ title, description }}>
+	<StructuredData type="person" />
 	<div class="measure-base mx-auto px-4b py-8b">
 
 		<!-- Page Header with description -->

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -60,7 +60,8 @@ export const siteConfig: SiteConfig = {
 			year: "numeric",
 		},
 	},
-	description: "Nathan Lane, PhD, Economist and Data Scientist",
+	description:
+		"Nathan Lane is an economist and data scientist at the London School of Economics studying industrial policy, economic development, and economic history.",
 	lang: "en-GB",
 	ogLocale: "en_GB",
 	title: "Nathan Lane, PhD",


### PR DESCRIPTION
Five small, surgical fixes from the code-review backlog (§11). Each was reviewed against source before commit.

## Changes
- **Person JSON-LD on `/about`** (SEO). The `person` schema existed in `StructuredData.astro` but was never rendered — the strongest academic-identity signal was unused. Now emitted. The unverified hardcoded `alumniOf: "Harvard University"` was **removed** rather than published as an unconfirmed claim.
- **Sitemap excludes `/og-image/`** (SEO). Image endpoints were being indexed as pages.
- **Longer default meta description** (SEO). ~46 → ~150 chars; it's the fallback for description-less pages plus the WebSite schema and webmanifest.
- **Footer a11y.** The "About this site" copy was a sentence-length `<a href="#">` (fake link / keyboard trap) — now a `<p>`. Footer section titles promoted `h3` → `h2` to fix an h1→h3 heading-order skip.
- **Stale secret-scan exclusion.** `private_notes/` → `.private/` (its gitignored successor) in `.gitsecret` and the `install-git-hooks.sh` fallback.

## Dropped from this batch
- ~~Add `check:assistant-docs` to the validate gate~~ — reverted. `AGENTS.md`/`CLAUDE.md` and their canonical source (`.private/docs/assistant-workflow.md`) are gitignored/local-only, so the check `ENOENT`s in CI. It can only ever be a local/pre-push concern, not part of the shared `validate` gate.

## Verification
- CI green on the PR branch
- `pnpm run validate` → 0 errors, 22/22 tests, 173 pages built
- Targeted output checks on fresh `dist/`: sitemap has **0** `/og-image/` URLs; `/about` emits the Person node with **no** `alumniOf`/Harvard; footer has **0** `href="#"` and renders the `<p>`.

## Follow-up (logged, not in this PR)
- The footer "About this site" `<p>` now sits inside `<nav aria-label="Footer navigation">` — pre-existing structure, mildly non-ideal semantically. Candidate for a future cleanup.