### PR TITLE
feat: SEO micro-fixes, dead-code prune, UTC dates, footer nav semantics

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import tailwind from "@astrojs/tailwind";
@@ -163,7 +162,6 @@ export default defineConfig({
 		optimizeDeps: {
 			exclude: ["@resvg/resvg-js"],
 		},
-		plugins: [rawFonts([".ttf", ".woff"])],
 	},
 	env: {
 		schema: {
@@ -189,19 +187,3 @@ export default defineConfig({
 		host: true,
 	},
 });
-
-function rawFonts(ext: string[]) {
-	return {
-		name: "vite-plugin-raw-fonts",
-		// @ts-expect-error:next-line
-		transform(_, id) {
-			if (ext.some((e) => id.endsWith(e))) {
-				const buffer = fs.readFileSync(id);
-				return {
-					code: `export default ${JSON.stringify(buffer)}`,
-					map: null,
-				};
-			}
-		},
-	};
-}

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -28,12 +28,6 @@ const socialImageURL = new URL(
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
 <title>{siteTitle}</title>
 
-{/* Font Preloading for Critical Fonts */}
-{/* Preconnect to speed up font loading */}
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-{/* DNS prefetch as fallback for browsers that don't support preconnect */}
-<link rel="dns-prefetch" href="https://fonts.gstatic.com" />
-
 {/* Enhanced Font Loading Strategy - Critical Fonts with Metrics-Matched Fallbacks */}
 <style>
   /* Metrics-matched fallback system to prevent layout shift */
@@ -127,6 +121,7 @@ const socialImageURL = new URL(
 <meta content={siteConfig.title} property="og:site_name" />
 <meta content={siteConfig.ogLocale} property="og:locale" />
 <meta content={socialImageURL} property="og:image" />
+<meta content={title} property="og:image:alt" />
 <meta content="1200" property="og:image:width" />
 <meta content="630" property="og:image:height" />
 {
@@ -139,15 +134,16 @@ const socialImageURL = new URL(
 }
 
 {/* Twitter */}
-<meta content="summary_large_image" property="twitter:card" />
-<meta content={canonicalURL} property="twitter:url" />
-<meta content={title} property="twitter:title" />
-<meta content={description} property="twitter:description" />
-<meta content={socialImageURL} property="twitter:image" />
+<meta content="summary_large_image" name="twitter:card" />
+<meta content={canonicalURL} name="twitter:url" />
+<meta content={title} name="twitter:title" />
+<meta content={description} name="twitter:description" />
+<meta content={socialImageURL} name="twitter:image" />
+<meta content={title} name="twitter:image:alt" />
 {siteConfig.twitterHandle && (
   <>
-    <meta content={siteConfig.twitterHandle} property="twitter:site" />
-    <meta content={siteConfig.twitterHandle} property="twitter:creator" />
+    <meta content={siteConfig.twitterHandle} name="twitter:site" />
+    <meta content={siteConfig.twitterHandle} name="twitter:creator" />
   </>
 )}
 

--- a/src/components/StructuredData.astro
+++ b/src/components/StructuredData.astro
@@ -2,7 +2,7 @@
 import { siteConfig } from '@/site.config';
 // This component adds JSON-LD structured data to help search engines understand your content
 import type { BreadcrumbItem, StructuredDataContent, StructuredDataProps } from '@/types';
-import { stripTrailingSlash, toAbsoluteUrl } from '@/utils/url';
+import { toAbsoluteUrl } from '@/utils/url';
 
 export interface Props extends StructuredDataProps {}
 
@@ -10,7 +10,6 @@ const { type, data } = Astro.props;
 
 const siteBase = siteConfig.canonicalUrl;
 const configuredSiteHref = siteConfig.canonicalUrl;
-const configuredSiteHrefNoTrailingSlash = stripTrailingSlash(configuredSiteHref);
 const siteHref = siteBase?.toString() ?? "";
 
 const absoluteUrl = (value?: string) => toAbsoluteUrl(value, siteBase);
@@ -49,16 +48,6 @@ switch (type) {
       "name": siteConfig.title,
       "description": siteConfig.description,
       "author": personSchema,
-      "potentialAction": configuredSiteHrefNoTrailingSlash
-        ? {
-            "@type": "SearchAction",
-            "target": {
-              "@type": "EntryPoint",
-              "urlTemplate": `${configuredSiteHrefNoTrailingSlash}/tags/{search_term_string}/`,
-            },
-            "query-input": "required name=search_term_string",
-          }
-        : undefined,
     };
     break;
 

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -46,29 +46,41 @@ const currentYear = new Date().getFullYear();
 <footer class="site-footer">
 	<!-- Main Footer Content -->
 	<div class="footer-content">
-		<!-- Navigation Grid -->
-		<nav class="footer-nav" aria-label="Footer navigation">
+		<!-- Navigation Grid: the nav landmark wraps only the link columns
+		     (display:contents keeps them as direct grid items); informational
+		     copy renders as a sibling, outside the nav landmark. -->
+		<div class="footer-nav">
+			<nav class="footer-nav-links" aria-label="Footer navigation">
+				{
+					footerSections
+						.filter((section) => section.links)
+						.map((section) => (
+							<div class="footer-section">
+								<h2 class="footer-section-title">{section.title}</h2>
+								<ul class="footer-links">
+									{(section.links || []).map((link) => (
+										<li>
+											<a href={link.href} class="link-footer">
+												{link.title}
+											</a>
+										</li>
+									))}
+								</ul>
+							</div>
+						))
+				}
+			</nav>
 			{
-				footerSections.map((section) => (
-					<div class="footer-section">
-						<h2 class="footer-section-title">{section.title}</h2>
-						{section.text ? (
+				footerSections
+					.filter((section) => section.text)
+					.map((section) => (
+						<div class="footer-section">
+							<h2 class="footer-section-title">{section.title}</h2>
 							<p class="footer-section-text">{section.text}</p>
-						) : (
-							<ul class="footer-links">
-								{(section.links || []).map((link) => (
-									<li>
-										<a href={link.href} class="link-footer">
-											{link.title}
-										</a>
-									</li>
-								))}
-							</ul>
-						)}
-					</div>
-				))
+						</div>
+					))
 			}
-		</nav>
+		</div>
 	</div>
 
 	<!-- Bottom Bar -->
@@ -116,6 +128,12 @@ const currentYear = new Date().getFullYear();
 		line-height: 1.5;
 		opacity: 0.64;
 		color: var(--theme-color-600);
+	}
+
+	/* nav landmark wraps only the link columns without forming its own grid box,
+	   so its children participate directly in the .footer-nav grid */
+	.footer-nav-links {
+		display: contents;
 	}
 
 	/* Improved navigation grid with musical spacing */

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -58,6 +58,7 @@ export const siteConfig: SiteConfig = {
 			day: "numeric",
 			month: "short",
 			year: "numeric",
+			timeZone: "UTC",
 		},
 	},
 	description:

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -25,6 +25,7 @@ export function formatDate(date: Date): string {
 		year: "numeric",
 		month: "long",
 		day: "numeric",
+		timeZone: "UTC",
 	});
 }
 
@@ -32,6 +33,7 @@ export function formatMonthYear(date: Date): string {
 	return date.toLocaleDateString("en-US", {
 		year: "numeric",
 		month: "2-digit",
+		timeZone: "UTC",
 	});
 }
 


### PR DESCRIPTION
Four grouped fixes from the code-review backlog (§11). Reviewed against source before commit; decisions confirmed with the maintainer up front.

## Changes
- **SEO — social image alt + Twitter tag form** (`BaseHead.astro`). Added `og:image:alt` and `twitter:image:alt` (page title). Converted the `twitter:*` meta from `property=` to the spec-correct `name=`.
- **SEO — drop bogus SearchAction** (`StructuredData.astro`). The WebSite schema advertised a sitelinks search box pointing at `/tags/{query}/`, which 404s for any non-tag query. Removed it (plus the now-unused `stripTrailingSlash` import/helper).
- **Dead-code prune.** Removed the unused `rawFonts` vite plugin + its `@ts-expect-error` and the now-unused `node:fs` import (`astro.config.ts`) — no `.ttf`/`.woff` JS imports exist; fonts load via `@fontsource` + CSS `url()`. Removed the dead `fonts.gstatic.com` preconnect/dns-prefetch (`BaseHead.astro`) — no Google Fonts are used.
- **Dates → UTC.** Pinned date-only rendering to UTC in `site.config.ts` **and** the `formatDate`/`formatMonthYear` helpers, so posts don't render off-by-one in non-UTC local/preview environments (prod CI is already UTC).
- **a11y — footer nav semantics.** The "About this site" prose was inside `<nav aria-label="Footer navigation">`. The nav now wraps only the link columns; `display: contents` keeps them as direct grid items, so the 4-column layout is unchanged and the prose sits outside the nav landmark.

## Verification
- `pnpm run validate` → 0 errors, 22/22 tests, 173 pages
- Targeted `dist/` checks: 0 `gstatic` refs; `og:image:alt` + `twitter:image:alt` present; 0 `property=` twitter tags; 0 `SearchAction`; nav wraps only links; 4 footer columns render.

## Notes
- `display: contents` on the `<nav>` preserves the navigation landmark in current (2026) evergreen browsers (the old a11y-tree bug was fixed years ago); residual risk limited to long-unpatched legacy engines.