### PR TITLE
chore: add post-merge cleanup + deploy-verify scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
 		"smoke:prod": "node scripts/validation/smoke-test.mjs https://nathanlane.info",
 		"smoke:pages": "node scripts/validation/pages-origin-redirect-smoke.mjs",
 		"smoke:live": "pnpm run smoke:prod && pnpm run smoke:pages",
+		"sync": "bash scripts/maintenance/sync-main.sh",
+		"verify:deploy": "bash scripts/validation/verify-deploy.sh",
 		"test": "vitest --run",
 		"test:ui": "vitest --ui",
 		"pre-push": "pnpm run validate",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,8 @@ This directory contains a mix of active maintenance utilities and older migratio
 | `scripts/maintenance/generate-cms-config.mjs` | Generate or check the Decap CMS config from the shared content contract | `pnpm run generate:cms` or `pnpm run check:cms` |
 | `scripts/maintenance/generate-social-card.mjs` | Generate or check `public/social-card.png` from the SVG source | `pnpm run generate:social-card` or `pnpm run check:social-card` |
 | `scripts/maintenance/sync-assistant-docs.mjs` | Generate or check the root assistant instruction files from the canonical workflow doc | `pnpm run generate:assistant-docs` or `pnpm run check:assistant-docs` |
+| `scripts/maintenance/sync-main.sh` | Fast-forward local `main` and prune local branches whose remote was deleted (post-merge cleanup) | `pnpm run sync` |
+| `scripts/validation/verify-deploy.sh` | Wait for the latest `main` Pages deploy to finish, then run the live smoke suite | `pnpm run verify:deploy` |
 | `scripts/diagnose-deps.sh` | Quick dependency and environment diagnostics | `./scripts/diagnose-deps.sh` |
 | `scripts/find-content-issues.js` | Scan content for frontmatter or quality issues | `node scripts/find-content-issues.js` |
 | `scripts/fix-content.js` | Apply automatic fixes to common content issues | `node scripts/fix-content.js` |

--- a/scripts/maintenance/sync-main.sh
+++ b/scripts/maintenance/sync-main.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# sync-main.sh — sync local `main` with origin and prune merged feature branches.
+#
+# Run this after a PR is merged on GitHub. It fast-forwards local main, prunes
+# stale remote-tracking refs, and deletes local branches whose upstream was
+# deleted on the remote (the reliable signal after a squash-merge + branch
+# delete). Squash-merged branches aren't recognized as "merged" by `git -d`, so
+# gone branches are force-deleted — the deleted SHA is printed for reflog
+# recovery. Branches that still track a live remote (e.g. origin/main) are left
+# untouched.
+#
+# Written for bash 3.2 (macOS default): no mapfile/readarray.
+set -euo pipefail
+
+if [ -n "$(git status --porcelain)" ]; then
+	echo "✗ Working tree not clean. Commit or stash your changes first." >&2
+	exit 1
+fi
+
+git switch main
+git pull --ff-only
+git fetch --prune
+
+gone=$(git for-each-ref --format '%(refname:short) %(upstream:track)' refs/heads |
+	awk '$2 == "[gone]" { print $1 }')
+
+if [ -z "$gone" ]; then
+	echo "✓ main up to date. No branches with a deleted upstream to prune."
+	exit 0
+fi
+
+count=0
+echo "Pruning branch(es) whose remote was deleted:"
+while IFS= read -r b; do
+	[ -z "$b" ] && continue
+	sha=$(git rev-parse --short "$b")
+	git branch -D "$b" >/dev/null
+	echo "  ✓ deleted $b (was $sha — recover with: git branch $b $sha)"
+	count=$((count + 1))
+done <<<"$gone"
+echo "✓ Done. Pruned $count branch(es)."

--- a/scripts/validation/verify-deploy.sh
+++ b/scripts/validation/verify-deploy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# verify-deploy.sh — wait for the latest main Pages deploy, then smoke-test prod.
+#
+# Run this after a merge to main once GitHub Actions has picked up the push. It
+# watches the newest `deploy.yml` run on main until it finishes (failing loudly
+# if the deploy fails), then runs the live smoke suite (`smoke:prod` followed by
+# the Pages-origin redirect smoke). If the run has already completed, `gh run
+# watch` returns immediately.
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+	echo "✗ GitHub CLI (gh) is required: https://cli.github.com" >&2
+	exit 1
+fi
+
+echo "Finding the latest deploy.yml run on main..."
+runid=$(gh run list --workflow deploy.yml --branch main --limit 1 --json databaseId -q '.[0].databaseId')
+
+if [ -z "$runid" ]; then
+	echo "✗ No deploy.yml run found on main." >&2
+	exit 1
+fi
+
+echo "Watching deploy run $runid (waits until it finishes)..."
+gh run watch "$runid" --exit-status
+
+echo ""
+echo "✓ Deploy succeeded. Running live smoke (prod + Pages-origin redirects)..."
+pnpm run smoke:live


### PR DESCRIPTION
Automates the repetitive post-merge cleanup into two explicit, manually-invoked pnpm commands (kept separate so you can run either independently).

## Commands
- **`pnpm run sync`** (`scripts/maintenance/sync-main.sh`) — local cleanup, no network beyond git:
  - fast-forwards local `main`, prunes stale remote-tracking refs
  - force-deletes local branches whose upstream was deleted (the reliable signal after a squash-merge, which `git branch -d` won't recognize as merged)
  - refuses on a dirty working tree; prints each deleted SHA for reflog recovery; leaves branches tracking a live remote (e.g. `origin/main`) untouched
- **`pnpm run verify:deploy`** (`scripts/validation/verify-deploy.sh`) — post-deploy verification:
  - watches the latest `main` `deploy.yml` run to completion (fails loudly if the deploy failed)
  - then runs the live smoke suite (`smoke:prod` + Pages-origin redirect smoke)

## Notes
- Written for **bash 3.2** (macOS default) — no `mapfile`/`readarray`.
- `verify:deploy` requires the GitHub CLI (`gh`); it checks and errors clearly if absent.
- Documented both in `scripts/README.md`.

## Verification
- `shellcheck` clean on both scripts; `bash -n` syntax OK
- `verify:deploy` tested live end-to-end (watched the green #73 deploy → smoke 13/13 + redirects 5/5)
- `sync` tested both paths: dirty-tree guard refuses; clean-tree run fast-forwards, prunes a stale ref, and correctly reports no gone branches