### PR TITLE
test: fix KaTeX smoke marker for conditional CSS loading

### DIFF
--- a/scripts/validation/smoke-test.mjs
+++ b/scripts/validation/smoke-test.mjs
@@ -34,8 +34,10 @@ const CHECKS = [
 	{ path: "/", marker: "Nathan Lane" },
 	{ path: "/about/", marker: "Nathan Lane" },
 	{ path: "/research/", marker: "Nathan Lane" },
-	// katex math must render in this paper page
-	{ path: "/research/manufacturing-revolutions/", marker: "katex" },
+	{ path: "/research/manufacturing-revolutions/", marker: "Nathan Lane" },
+	// KaTeX renders on a page that actually contains math; its self-hosted CSS is
+	// now loaded conditionally, so this must be a genuine math page (not any page).
+	{ path: "/posts/uncomtrade/", marker: "katex" },
 	{ path: "/writing/", marker: "Nathan Lane" },
 	{ path: "/writing/a-flight-plan-that-fails-boston-review/", marker: "Nathan Lane" },
 	{ path: "/posts/", marker: "Nathan Lane" },


### PR DESCRIPTION
Follow-up to PR #77 (self-hosted conditional KaTeX). The post-deploy smoke test failed 1/13, correctly catching a now-stale assertion.

## What happened
`smoke-test.mjs` asserted the `"katex"` marker on `/research/manufacturing-revolutions/` ("katex math must render in this paper page"). But that paper contains **no math** — the marker only ever passed because the old global CDN KaTeX `<link>` put "katex" on every page. With conditional loading, that page correctly ships no KaTeX, so the assertion failed.

**Not a production bug** — the site is correct; the test's assumption was wrong.

## Fix
- Point the KaTeX assertion at `/posts/uncomtrade/`, a page that genuinely renders math — so the check now meaningfully verifies conditional self-hosted loading.
- Keep `/research/manufacturing-revolutions/` in the smoke set with a valid generic marker (`Nathan Lane`) for research-page coverage.

## Verification
- `smoke:prod` against https://nathanlane.info → **14/14** (both the new uncomtrade KaTeX check and the fixed research check pass).