### PR TITLE
chore: bump GitHub Actions majors and align pnpm via packageManager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
 
     steps:
       # Checkout code
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history required for gitleaks detect
 
@@ -30,15 +30,14 @@ jobs:
 
       # Setup Node.js
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
-      # Install pnpm
+      # Install pnpm (version comes from package.json "packageManager")
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
           run_install: false
 
       # Get pnpm store directory for caching
@@ -50,7 +49,7 @@ jobs:
 
       # Cache pnpm dependencies
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -72,7 +71,7 @@ jobs:
 
       # Upload build artifacts (optional)
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,17 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
+      # pnpm version comes from package.json "packageManager"
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v6
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -34,7 +33,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -52,7 +51,7 @@ jobs:
         run: pnpm run validate
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -72,4 +71,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "nathanlane.github.io",
 	"version": "1.0.0",
+	"packageManager": "pnpm@11.9.0",
+	"engines": {
+		"node": ">=20"
+	},
 	"scripts": {
 		"dev": "astro dev --port 4321",
 		"start": "astro dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,11 +3,6 @@ allowBuilds:
   esbuild: true
   sharp: true
 
-onlyBuiltDependencies:
-  - "@biomejs/biome"
-  - esbuild
-  - sharp
-
 overrides:
   "tar-fs@2": "2.1.4"
   "tar-fs@3": "3.1.2"


### PR DESCRIPTION
## Summary

Backlog: GitHub Actions Node-20 runtime deprecation (forced to Node 24 since 2026-06-16, old runtimes removed **2026-09-16**) plus pnpm 10/11 config drift between CI and local.

- **Action majors:** `checkout` v4→v7, `setup-node` v4→v6, `pnpm/action-setup` v2→v6, `cache` v4→v6, `upload-artifact` v4→v7, `upload-pages-artifact` v3→v5, `deploy-pages` v4→v5 (both workflows).
- **pnpm single source of truth:** added `"packageManager": "pnpm@11.9.0"` to package.json (matches local); dropped the `version: 10` input so `pnpm/action-setup` reads it from there. CI and local now both run pnpm 11.
- **Build-script config:** removed the redundant `onlyBuiltDependencies` block (pnpm 10 syntax) from pnpm-workspace.yaml; `allowBuilds` (pnpm 11) is now the only mechanism.
- **Node:** added `engines.node >=20`; bumped workflow Node 20 → 24 (Node 20 went EOL 2026-04; 24 is active LTS). Note this renames the CI check to `build (24.x)` — no ruleset requires the old name.

## Verification

- `pnpm install --frozen-lockfile` clean under pnpm 11.9.0 with `allowBuilds` only; lockfile untouched
- `pnpm run validate` green locally (lint, format, generated checks, astro check, tests, build — 173 pages)
- Confirmed via pnpm/action-setup docs that omitting `version` makes it read the `packageManager` field